### PR TITLE
Update `react-native-easy-grid` to 1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "15.4.1",
     "react-native": "0.39.2",
     "react-native-code-push": "1.15.0-beta",
-    "react-native-easy-grid": "0.1.6",
+    "react-native-easy-grid": "0.1.7",
     "react-native-modalbox": "^1.3.4",
     "react-native-navigation-redux-helpers": "^0.4.1",
     "react-native-vector-icons": "^2.0.3",


### PR DESCRIPTION
Fixes https://github.com/GeekyAnts/NativeBase-KitchenSink/issues/11#issuecomment-266472597

The package.json still refers to 1.6 of react-native-easy-grid, which references the file the old way (see GeekyAnts/NativeBase#336).

When I changed its version spec to 1.7 it worked.
