### PR TITLE
Upgraded CRNA to Expo sdkVersion v30.0.0, also react-native.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NativeBase KitchenSink v2.5.0
+# NativeBase KitchenSink v2.7.1
 An example app with all the UI components of NativeBase
 
 > **NativeBase-KitchenSink** comes in four forms of app for you!

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "sdkVersion": "28.0.0",
+    "sdkVersion": "30.0.0",
     "icon": "./assets/nblogo.png",
     "slug": "nativebasekitchensink",
     "loading": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativebaseKitchenSink",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "private": true,
   "devDependencies": {
     "babel-eslint": "7.2.3",
@@ -14,11 +14,11 @@
     "flow-bin": "0.52.0",
     "flow-typed": "2.1.5",
     "husky": "0.14.3",
-    "jest": "20.0.4",
+    "jest": "23.3.0",
     "jest-expo": "28.0.0",
     "prettier": "1.5.3",
     "react-native-scripts": "1.11.1",
-    "react-test-renderer": "16.2.0"
+    "react-test-renderer": "16.4.1"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
   "scripts": {
@@ -36,9 +36,9 @@
     "expo": "28.0.0",
     "lodash": "4.13.1",
     "moment": "2.13.0",
-    "native-base": "2.5.2",
-    "react": "16.3.1",
-    "react-native": "0.55.4",
+    "native-base": "2.7.0",
+    "react": "16.4.1",
+    "react-native": "0.56.0",
     "react-navigation": "1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativebaseKitchenSink",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "devDependencies": {
     "babel-eslint": "7.2.3",
@@ -20,12 +20,12 @@
     "react-native-scripts": "1.11.1",
     "react-test-renderer": "16.4.1"
   },
-  "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
+  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "react-native-scripts start",
-    "eject": "react-native-scripts eject",
-    "android": "react-native-scripts android",
-    "ios": "react-native-scripts ios",
+    "start": "expo start",
+    "eject": "expo eject",
+    "android": "expo --android",
+    "ios": "expo --ios",
     "test": "node node_modules/jest/bin/jest.js --watch"
   },
   "jest": {
@@ -33,12 +33,12 @@
   },
   "dependencies": {
     "color": "1.0.3",
-    "expo": "28.0.0",
+    "expo": "^30.0.1",
     "lodash": "4.13.1",
     "moment": "2.13.0",
-    "native-base": "2.7.0",
-    "react": "16.4.1",
-    "react-native": "0.56.0",
+    "native-base": "2.8.0",
+    "react": "16.3.1",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-30.0.0.tar.gz",
     "react-navigation": "1.5.0"
   }
 }


### PR DESCRIPTION
I have upgraded expo to sdkVersion: v30.0.0. Also, upgraded react & react-native dependencies.

Other dependencies upgraded to equal of master branch. However, it may be upgraded to latest version, but now i transfer it to community now.

* I had tested these upgradation and working seamlessly at my instance. Comments are most welcome.
Pull request respected to issue: https://github.com/GeekyAnts/NativeBase-KitchenSink/issues/138